### PR TITLE
Install htop after EPEL is installed

### DIFF
--- a/ansible/getip.yml
+++ b/ansible/getip.yml
@@ -9,7 +9,6 @@
         - gcc
         - gdb
         - gnutls-utils
-        - htop
         - epel-release
         - lsof
         - ltrace
@@ -20,6 +19,13 @@
         - tmux
         - traceroute
       state: present
+
+  - name: Install htop
+    yum:
+      name:
+        - htop
+      state: present
+      update_cache: true
 
   - name: asciinema playback
     shell: pip3 install asciinema


### PR DESCRIPTION
Install htop after EPEl, otherwise you'll get:

```
TASK [gcc and debuginfo rpms] **************************************************
fatal: [getip]: FAILED! => {"changed": false, "msg": "No package matching 'htop' found available, installed or updated", "rc": 126, "results": ["No package matching 'htop' found available, installed or updated"]}```
